### PR TITLE
Node-Red Debug window showing misleading information / Return JSON only on SOQL (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.3
+
+- Added "returnJSON" to SOQL node to address: 
+  - Node-Red Debug window showing misleading information #5
+  - bug in how soql queries return in node-red #19
+
+## 0.2.2 
+
+- Fix query variable scope on soql and sosl nodes (#14) 
+
 ## 0.2.1
 
 - Fixed bug that prevented subscriptions from completion

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ select id, name
 from contact
 limit 2
 ```
-
-The resulting message has the following properties:
+If "Return JSON only" is selected, message.payload contains an array of result objects.
+Otherwise the resulting message has the following properties:
 
 - msg.payload.size - the number of records returned from the query
 - msg.payload.records - the array of records returned from the query.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If "Return JSON only" is selected, message.payload contains an array of result o
 Otherwise the resulting message has the following properties:
 
 - msg.payload.size - the number of records returned from the query
-- msg.payload.records - the array of javascript nForce objects returned from the query. The nforce objects are useful for doing updates etc., as they have dirty checking and are already structured for an DML update, but do not match what Node-Red debug window.
+- msg.payload.records - the array of javascript nForce objects returned from the query. The nforce objects are useful for doing updates etc., as they have dirty checking and are already structured for an DML update, but do not match what Node-Red debug window shows.
 
 The query can be configured in the node, however if left blank, the query should be set in an incoming message on `msg.query`. See the [Salesforce SOQL documentation](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl) for more information.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If "Return JSON only" is selected, message.payload contains an array of result o
 Otherwise the resulting message has the following properties:
 
 - msg.payload.size - the number of records returned from the query
-- msg.payload.records - the array of records returned from the query.
+- msg.payload.records - the array of javascript nForce objects returned from the query. The nforce objects are useful for doing updates etc., as they have dirty checking and are already structured for an DML update, but do not match what Node-Red debug window.
 
 The query can be configured in the node, however if left blank, the query should be set in an incoming message on `msg.query`. See the [Salesforce SOQL documentation](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl) for more information.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-salesforce",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "A set of Node-RED nodes to interact with Salesforce and Force.com.",
     "author": {
         "name": "Jeff Douglas",

--- a/soql.html
+++ b/soql.html
@@ -64,7 +64,7 @@
     <p>Otherwise the resulting message has the following properties:
         <ul>
             <li>msg.payload.size - the number of records returned from the query.</li>
-            <li>msg.payload.records - the array of javascript nForce objects returned from the query. The nforce objects are useful for doing updates etc., as they have dirty checking and are already structured for an DML update, but do not match what Node-Red debug window. </li>
+            <li>msg.payload.records - the array of javascript nForce objects returned from the query. The nforce objects are useful for doing updates etc., as they have dirty checking and are already structured for an DML update, but do not match what Node-Red debug window shows. </li>
         </ul>
     </p>
     <p>The query can be configured in the node, however if left blank, the query should be set in an incoming message on <code>msg.query</code>.</p>

--- a/soql.html
+++ b/soql.html
@@ -16,6 +16,9 @@
             },
             fetchAll: {
                 value: false
+            },
+            returnJSON: {
+                value: false
             }
         },
         inputs: 1,
@@ -44,6 +47,10 @@
         <label for="node-input-fetchAll"><i class="fa fa-list"></i> Fetch all result records</label>
         <input type="checkbox" id="node-input-fetchAll" style="position:absolute;left:20px" />
     </div>
+    <div class="form-row" style="white-space:nowrap">
+        <label for="node-input-returnJSON"><i class="fa fa-list"></i> Return JSON only</label>
+        <input type="checkbox" id="node-input-returnJSON" style="position:absolute;left:20px" />
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="soql">
@@ -52,11 +59,12 @@
   select id, name
   from contact
   limit 2
-</pre>
-    <p>The resulting message has the following properties:
+    </pre>
+    <p>If "Return JSON only" is selected, message.payload contains an array of result objects.</p>
+    <p>Otherwise the resulting message has the following properties:
         <ul>
             <li>msg.payload.size - the number of records returned from the query.</li>
-            <li>msg.payload.records - the array of records returned from the query.</li>
+            <li>msg.payload.records - the array of javascript nForce objects returned from the query. The nforce objects are useful for doing updates etc., as they have dirty checking and are already structured for an DML update, but do not match what Node-Red debug window. </li>
         </ul>
     </p>
     <p>The query can be configured in the node, however if left blank, the query should be set in an incoming message on <code>msg.query</code>.</p>

--- a/soql.js
+++ b/soql.js
@@ -44,13 +44,22 @@ module.exports = function(RED) {
             org
                 .authenticate({ username: this.connection.username, password: this.connection.password })
                 .then(function() {
-                    return org.query({ fetchAll: config.fetchAll, query: query });
+                    return org.query({ fetchAll: config.fetchAll, query: query }).error(function(err) {
+                        node.status({ fill: 'red', shape: 'dot', text: 'Error!' });
+                        node.error(err, msg);
+                    });
                 })
                 .then(function(results) {
-                    msg.payload = {
-                        size: results.totalSize,
-                        records: results.records
-                    };
+                    if (config.returnJSON) {
+                        msg.payload = results.records.map(function (record) {
+                            return record.toJSON();
+                        });
+                    } else {
+                        msg.payload = {
+                            size: results.totalSize,
+                            records: results.records
+                        };
+                    }
                     node.send(msg);
                     node.status({});
                 })


### PR DESCRIPTION
Changes for new "Return JSON only" feature on SOQL node. 

This addresses #5 "Node-Red Debug window showing misleading information"