### PR TITLE
Proposed fixes for Salesforce OAuth Error: invalid clientId

### DIFF
--- a/chatter.js
+++ b/chatter.js
@@ -33,10 +33,10 @@ module.exports = function (RED) {
 
             // auth and insert Feed Item
             nforce
-                .authenticate(orgResult.org, orgResult.config)
+                .authenticate(orgResult.connection, orgResult.config)
                 .then(result => {
                     const sobj = { sobject: payload };
-                    return orgResult.org.insert(sobj)
+                    return orgResult.connection.insert(sobj)
                         .catch(err => {
                             node.status({ fill: 'red', shape: 'dot', text: 'Error:' + e.message });
                             node.error(err, msg);

--- a/dml.js
+++ b/dml.js
@@ -21,7 +21,7 @@ module.exports = function(RED) {
 
       // Auth and run DML
       nforce
-        .authenticate(orgResult.org, orgResult.config)
+        .authenticate(orgResult.connection, orgResult.config)
         .then((oauth) => {
           let dmlResult;
           const org = orgResult.org;

--- a/nforce_wrapper.js
+++ b/nforce_wrapper.js
@@ -20,12 +20,19 @@ const createConnection = function(configOptionsRaw, msg) {
   if (configOptions.apiversion) {
     orgOptions.apiVersion = configOptions.apiversion;
   }
-
+  orgOptions.clientId = configOptions.consumerKey;
+  //console.log( 'configOptions: ' + JSON.stringify(configOptions,null,2) );
+  //console.log( 'OrgOptions: ' + JSON.stringify(orgOptions,null,2) );
   const connectionResult = nforce8.createConnection(orgOptions);
+  //console.log('ConnectionResult: ' + connectionResult);
+  connectionResult.clientSecret = configOptions.consumerSecret;
   const result = {
     connection: connectionResult,
     config: configOptions
   };
+  //console.log( 'Connection: ' + JSON.stringify(result.connection,null,2) );
+  //console.log( 'Config: ' + JSON.stringify(result.config,null,2) );
+
 
   return result;
 };
@@ -34,6 +41,7 @@ const createConnection = function(configOptionsRaw, msg) {
 // TODO: Token authentication for Salesforce roundtrip
 const authenticate = function(org, configOptions) {
   // TODO: Check if we have a incomign session
+  //console.log( 'Org: ' + org );
   return org.authenticate(configOptions);
 };
 
@@ -43,6 +51,8 @@ const authenticate = function(org, configOptions) {
  * @param {*} msg the actual incoming message that might contain identity information
  */
 const getConfig = function(configOptions, msg) {
+  //console.log( 'ConfigOptions: ' + JSON.stringify(configOptions) );
+  //console.log( 'Msg: ' + msg );
   configOptions = configOptions || {};
   const connectionOptionResult = Object.assign({}, configOptions);
   //  Check if  credentials from message overwrite credentials from config
@@ -63,6 +73,8 @@ const getConfig = function(configOptions, msg) {
     }
   }
 
+  //console.log('consumerKey: ' + connectionOptionResult.consumerKey);
+  //console.log('consumerSecret: ' + connectionOptionResult.consumerSecret);
   return connectionOptionResult;
 };
 

--- a/soql.js
+++ b/soql.js
@@ -19,7 +19,7 @@ module.exports = function (RED) {
 
             // create connection object
             const orgResult = nforce.createConnection(this.connection);
-            const org = orgResult.org;
+            const org = orgResult.connection;
             // auth and run query
             nforce
                 .authenticate(org, orgResult.config)

--- a/sosl.js
+++ b/sosl.js
@@ -17,7 +17,7 @@ module.exports = function (RED) {
 
             // create connection object
             const orgResult = nforce.createConnection(this.connection);
-            const org = orgResult.org;
+            const org = orgResult.connection;
 
 
             // auth and run query


### PR DESCRIPTION
With the move to nforce8, the nforce_wrapper.js was not passing the consumerKey or consumerSecret to the Connection constructor properly in the orgOptions variable. These have been added.

Along with the previous issue, the result object being returned was modified to hold two variables( connection and config). The methods for the different types of nodes were trying to use a variable named "org" which is the connection variable. Changes have been added where the org variable was being used in soql.js, sosl.js, dml.js, and chatter.js.

These changes should fix the authentication error.