### PR TITLE
Broken connection fix

### DIFF
--- a/chatter.js
+++ b/chatter.js
@@ -54,10 +54,10 @@ const handleInput = (node, msg) => {
 module.exports = function(RED) {
   function Chatter(config) {
     const node = this;
+    RED.nodes.createNode(node, config);
     node.connection = RED.nodes.getNode(config.connection);
     node.config = config;
     node.on('input', (msg) => handleInput(node, msg));
-    RED.nodes.createNode(node, config);
   }
   RED.nodes.registerType('chatter', Chatter);
 };

--- a/dml.js
+++ b/dml.js
@@ -61,12 +61,12 @@ const handleInput = (node, msg) => {
 };
 
 module.exports = function(RED) {
-  function Dml(config) {
+  function Dml(config) {    
     const node = this;
+    RED.nodes.createNode(node, config);    
     node.connection = RED.nodes.getNode(config.connection);
     node.config = config;
     node.on('input', (msg) => handleInput(node, msg));
-    RED.nodes.createNode(node, config);
   }
   RED.nodes.registerType('dml', Dml);
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "faye": "^1.2.4",
-    "nforce8": "^2.0.10",
+    "nforce8": "https://github.com/tempflip/nforce8#patch-1",
     "xml2js": "^0.4.19"
   },
   "scripts": {

--- a/soql.js
+++ b/soql.js
@@ -33,10 +33,10 @@ const handleInput = (node, msg) => {
 module.exports = function(RED) {
   function SoqlQuery(config) {
     const node = this;
+    RED.nodes.createNode(node, config);    
     node.connection = RED.nodes.getNode(config.connection);
     node.config = config;
     node.on('input', (msg) => handleInput(node, msg));
-    RED.nodes.createNode(node, config);
   }
   RED.nodes.registerType('soql', SoqlQuery);
 };

--- a/sosl.js
+++ b/sosl.js
@@ -31,10 +31,10 @@ const handleInput = (node, msg) => {
 module.exports = function(RED) {
   function SoslQuery(config) {
     const node = this;
+    RED.nodes.createNode(node, config);
     node.connection = RED.nodes.getNode(config.connection);
     node.config = config;
     node.on('input', (msg) => handleInput(node, msg));
-    RED.nodes.createNode(node, config);
   }
   RED.nodes.registerType('sosl', SoslQuery);
 };

--- a/streaming.js
+++ b/streaming.js
@@ -138,10 +138,10 @@ const handleInput = (node, msg) => {
 module.exports = function(RED) {
   function Streaming(config) {
     const node = this;
+    RED.nodes.createNode(node, config);    
     node.connection = RED.nodes.getNode(config.connection);
     setupSubscriptionNode(node, config);
     node.on('input', (msg) => handleInput(node, msg));
-    RED.nodes.createNode(node, config);
     actionHelper.idle(node);
   }
   RED.nodes.registerType('streaming', Streaming);


### PR DESCRIPTION
Connection part did not work with node-red v1.0.2 and node.js v12.13.0

Probably it is somehow connected to the event-registration mechanism, because if I move `RED.nodes.createNode(node, config)` line above the `node.on('input', (msg)....`, it works just fine.

The another thing I noticed that `nforce8` has a bug which affects responses -- so I created a PR; until it's fixed, I use in the `package.json` a reference to that branch. Once merged, please remove it from `package.json` !

https://github.com/Stwissel/nforce8/pull/26